### PR TITLE
Allow overriding simulation output suffixes; set _fusion_ou2/_fusion_ou3 for OU2/OU3 sims

### DIFF
--- a/bbn_wave_freq_m5atomS3/data-sim/W3dSimCommon.h
+++ b/bbn_wave_freq_m5atomS3/data-sim/W3dSimCommon.h
@@ -329,7 +329,9 @@ inline std::optional<W3dSimulationRunResult> process_wave_file_for_tracker(const
                                                                            float dt,
                                                                            bool with_mag,
                                                                            bool add_noise,
-                                                                           float mag_odr_hz)
+                                                                           float mag_odr_hz,
+                                                                           std::string output_suffix_with_mag = "_fusion",
+                                                                           std::string output_suffix_no_mag = "_fusion_nomag")
 {
     const float acc_sigma = 1.51e-3f * g_std;
     const float gyr_sigma = 0.00157f;
@@ -357,6 +359,8 @@ inline std::optional<W3dSimulationRunResult> process_wave_file_for_tracker(const
     options.add_noise = add_noise;
     options.mag_odr_hz = mag_odr_hz;
     options.temperature_c = 35.0f;
+    options.output_suffix_with_mag = std::move(output_suffix_with_mag);
+    options.output_suffix_no_mag = std::move(output_suffix_no_mag);
 
     W3dSimulationRunner runner(options, std::move(noise_models), adapter);
     return runner.run(filename);

--- a/bbn_wave_freq_m5atomS3/data-sim/w3d_sim_adapt_3.cpp
+++ b/bbn_wave_freq_m5atomS3/data-sim/w3d_sim_adapt_3.cpp
@@ -128,7 +128,7 @@ static constexpr W3dSummaryLabels SUMMARY_LABELS{
 static void process_wave_file_for_tracker(const std::string& filename, float dt, bool with_mag)
 {
     constexpr float MAG_ODR_HZ = 100.0f;
-    auto result = process_wave_file_for_tracker<FusionAdapter3>(filename, dt, with_mag, add_noise, MAG_ODR_HZ);
+    auto result = process_wave_file_for_tracker<FusionAdapter3>(filename, dt, with_mag, add_noise, MAG_ODR_HZ, "_fusion_ou3", "_fusion_ou3_nomag");
     if (!result) return;
     print_summary_and_fail_if_needed(*result, dt, FAIL_LIMITS, SUMMARY_LABELS);
 }

--- a/bbn_wave_freq_m5atomS3/data-sim/w3d_sim_adapt_4.cpp
+++ b/bbn_wave_freq_m5atomS3/data-sim/w3d_sim_adapt_4.cpp
@@ -128,7 +128,7 @@ static constexpr W3dSummaryLabels SUMMARY_LABELS{
 static void process_wave_file_for_tracker(const std::string& filename, float dt, bool with_mag)
 {
     constexpr float MAG_ODR_HZ = 25.0f;
-    auto result = process_wave_file_for_tracker<FusionAdapter4>(filename, dt, with_mag, add_noise, MAG_ODR_HZ);
+    auto result = process_wave_file_for_tracker<FusionAdapter4>(filename, dt, with_mag, add_noise, MAG_ODR_HZ, "_fusion_ou2", "_fusion_ou2_nomag");
     if (!result) return;
     print_summary_and_fail_if_needed(*result, dt, FAIL_LIMITS, SUMMARY_LABELS);
 }


### PR DESCRIPTION
### Motivation
- Make it possible for specific fusion-adapter simulation binaries to write distinct output filename suffixes instead of the generic `_fusion` so outputs from different filter variants are clearly separated.
- Keep existing behavior for other callers by providing default suffix values so this change is minimally invasive.

### Description
- Extended the template helper `process_wave_file_for_tracker` in `bbn_wave_freq_m5atomS3/data-sim/W3dSimCommon.h` with two optional parameters `output_suffix_with_mag` and `output_suffix_no_mag` defaulting to `"_fusion"` and `"_fusion_nomag"` respectively, and applied them to `W3dSimulationOptions` before running the runner.
- Updated `bbn_wave_freq_m5atomS3/data-sim/w3d_sim_adapt_3.cpp` to call the helper with `"_fusion_ou3"` / `"_fusion_ou3_nomag"` so OU3 simulation outputs use `_fusion_ou3`.
- Updated `bbn_wave_freq_m5atomS3/data-sim/w3d_sim_adapt_4.cpp` to call the helper with `"_fusion_ou2"` / `"_fusion_ou2_nomag"` so OU2 simulation outputs use `_fusion_ou2`.
- Changes are limited to the data-sim directory and preserve existing default behavior for callers that don't pass the new arguments.

### Testing
- Run `make all` in repository root `/workspace/bbn-wave-period-esp32` which failed with: `make: *** No rule to make target 'all'.  Stop.`
- Run `make all` in `bbn_wave_freq_m5atomS3/data-sim` which succeeded and produced the expected simulation binaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c809c1d7dc8328a9ad92ab12f70f0f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced output file naming flexibility for wave file processing in data simulation, allowing different fusion adapters to use customized output identifiers for their processed datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->